### PR TITLE
Added query params

### DIFF
--- a/core/Client.php
+++ b/core/Client.php
@@ -48,35 +48,52 @@ class Client {
 		
 		return $r->body;
 	}
-	public function contentTypes ($space_id) {
-		$r = Unirest::get ("https://cdn.contentful.com/spaces/{$space_id}/content_types");
+	public function contentTypes ($space_id, $params = '') {
+		$params = $this -> buildparams($params);
+		$r = Unirest::get ("https://cdn.contentful.com/spaces/{$space_id}/content_types{$params}");
 		
 		return $r->body;
 	}
-	public function contentType ($id, $space_id) {
-		$r = Unirest::get ("https://cdn.contentful.com/spaces/{$space_id}/content_types/{$id}");
+	public function contentType ($id, $space_id, $params = '') {
+		$params = $this -> buildparams($params);
+		$r = Unirest::get ("https://cdn.contentful.com/spaces/{$space_id}/content_types/{$id}{$params}");
 		
 		return $r->body;
 	}
-	public function entries ($space_id) {
-		$r = Unirest::get ("https://cdn.contentful.com/spaces/{$space_id}/entries");
+	public function entries ($space_id, $params = '') {
+		$params = $this -> buildparams($params);
+		$r = Unirest::get ("https://cdn.contentful.com/spaces/{$space_id}/entries{$params}");
 		
 		return $r->body;
 	}
-	public function entry ($id, $space_id) {
-		$r = Unirest::get ("https://cdn.contentful.com/spaces/{$space_id}/entries/{$id}");
+	public function entry ($id, $space_id, $params = '') {
+		$params = $this -> buildparams($params);
+		$r = Unirest::get ("https://cdn.contentful.com/spaces/{$space_id}/entries/{$id}{$params}");
 		
 		return $r->body;
 	}
-	public function assets ($space_id) {
-		$r = Unirest::get ("https://cdn.contentful.com/spaces/{$space_id}/assets");
+	public function assets ($space_id, $params = '') {
+		$params = $this -> buildparams($params);
+		$r = Unirest::get ("https://cdn.contentful.com/spaces/{$space_id}/assets{$params}");
 		
 		return $r->body;
 	}
-	public function asset ($id, $space_id) {
-		$r = Unirest::get ("https://cdn.contentful.com/spaces/{$space_id}/assets/{$id}");
+	public function asset ($id, $space_id, $params = '') {
+		$params = $this -> buildparams($params);
+		$r = Unirest::get ("https://cdn.contentful.com/spaces/{$space_id}/assets/{$id}{$params}");
 		
 		return $r->body;
+	}
+	private function buildparams($params) {
+		if(empty($params)) return '';
+		
+		if(is_array($params)) {
+			foreach($params as $key=>$value) {
+				$p_array[] = urlencode($key) . "=" . urlencode($value);
+			}
+			$result = implode("&",$p_array);
+		} else $result = $params;
+		return '?'.$result;
 	}
 	
 }

--- a/examples/demo.php
+++ b/examples/demo.php
@@ -21,3 +21,11 @@ $entry = $client->entry ('nyancat', 'cfexampleapi');
 $assets = $client->assets ('cfexampleapi');
 $asset = $client->asset ('nyancat', 'cfexampleapi');
 
+//Using params
+
+$entries = $client->entries ('cfexampleapi', 'skip=2&limit=2'); //params as a string
+
+$params['skip'] 	= 2;
+$params['limit'] 	= 2;
+$params['content_type'] 	= 'cat';
+$entries = $client->entries ('cfexampleapi', $params); //params as array


### PR DESCRIPTION
Added query params for requests. Can be used as string or as arrays. There are examples in demo.php

This feature is used to add limits/skip/content_type and other params.
